### PR TITLE
Update composer to require getcandy/core vs admin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "getcandy/admin": "^2.0-beta"
+        "getcandy/core": "^2.0-beta"
     },
     "require-dev": {
         "cartalyst/converter": "^6.1|^7.0",


### PR DESCRIPTION
We was initial requiring `getcandy/admin` which is the `hub` (which in itself requires the core). However, because this package does not rely on the "hub", we update the require to `getcandy/core` instead.

*Note: `getcandy/admin` is still required if you enable the hub screens in the configuration file (see README.md)*