### PR TITLE
Fix mixin laravel relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ $favoriteItems->find(1)->get();
 
 ```php
 // all favorites by this user
-$user->favorites()->count();
+$user->favorites->count();
 
 // how many Products has this user favorited ?
 $user->favorites()->withType(Product::class)->count();
 
 // how many users favorited this product ?
-$product->favoriters()->count();
+$product->favoriters->count();
 ```
 
 List with `*_count` attribute:

--- a/src/GetCandyFavoritesServiceProvider.php
+++ b/src/GetCandyFavoritesServiceProvider.php
@@ -49,6 +49,23 @@ class GetCandyFavoritesServiceProvider extends ServiceProvider
     private function registerMixins()
     {
         Product::mixin(new GetCandyFavoriteableMixins());
+
+        // Define Mixin relationships
+        Product::resolveRelationUsing('favorites', function ($model) {
+            return $model->morphMany(config('favorite.favorite_model'), 'favoriteable');
+        });
+
+        Product::resolveRelationUsing('favoriters', function ($model) {
+            $prefix = config('getcandy.database.table_prefix');
+
+            return $model->belongsToMany(
+                config('auth.providers.users.model'),
+                $prefix . config('favorite.favorites_table'),
+                'favoriteable_id',
+                config('favorite.user_foreign_key')
+            )
+                ->where('favoriteable_type', $this->getMorphClass());
+        });
     }
 
     /**

--- a/src/Traits/FavoriteableMixin.php
+++ b/src/Traits/FavoriteableMixin.php
@@ -33,26 +33,4 @@ trait FavoriteableMixin
             return false;
         };
     }
-
-    public function favorites()
-    {
-        return function () {
-            return $this->morphMany(config('favorite.favorite_model'), 'favoriteable');
-        };
-    }
-
-    public function favoriters()
-    {
-        $prefix = config('getcandy.database.table_prefix');
-
-        return function () use ($prefix) {
-            return $this->belongsToMany(
-                config('auth.providers.users.model'),
-                $prefix . config('favorite.favorites_table'),
-                'favoriteable_id',
-                config('favorite.user_foreign_key')
-            )
-                ->where('favoriteable_type', $this->getMorphClass());
-        };
-    }
 }

--- a/tests/Feature/GetCandyFavoriteableProductTest.php
+++ b/tests/Feature/GetCandyFavoriteableProductTest.php
@@ -58,7 +58,7 @@ class GetCandyFavoriteableProductTest extends TestCase
         $user->favorite($post1);
         $user->favorite($post2);
 
-        $this->assertSame(4, $user->favorites()->count());
+        $this->assertSame(4, $user->favorites->count());
         $this->assertSame(2, $user->favorites()->withType(Product::class)->count());
     }
 }


### PR DESCRIPTION
The laravel relationships were being defined in the mixin incorrectly which was causing laravel to not be able to resolve the property version of the relationships.

Example `$product->favoriters` would return `null` when it should return a collection.